### PR TITLE
Feat/real time log streamer

### DIFF
--- a/wazuh-agent-status-rust-client/package-lock.json
+++ b/wazuh-agent-status-rust-client/package-lock.json
@@ -1771,9 +1771,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "dev": true,
       "funding": [
         {

--- a/wazuh-agent-status-rust-client/src-tauri/src/agent.rs
+++ b/wazuh-agent-status-rust-client/src-tauri/src/agent.rs
@@ -150,6 +150,39 @@ impl AgentManager {
 
         Ok(rx)
     }
+
+    pub async fn stream_logs(&self) -> anyhow::Result<tokio::sync::mpsc::Receiver<String>> {
+        let (tx, rx) = tokio::sync::mpsc::channel(256);
+        let server_addr = self.server_addr.clone();
+
+        tokio::spawn(async move {
+            let mut stream = match tokio::net::TcpStream::connect(&server_addr).await {
+                Ok(s) => s,
+                Err(e) => {
+                    let _ = tx.send(format!("[ERROR] Failed to connect to server for logs: {e}")).await;
+                    return;
+                }
+            };
+
+            use tokio::io::{AsyncWriteExt, AsyncBufReadExt};
+            if let Err(e) = stream.write_all(b"subscribe-logs\n").await {
+                let _ = tx.send(format!("[ERROR] Failed to send log subscription: {e}")).await;
+                return;
+            }
+
+            let mut reader = tokio::io::BufReader::new(stream);
+            let mut line = String::new();
+            while let Ok(n) = reader.read_line(&mut line).await {
+                if n == 0 { break; }
+                if let Some(json) = line.strip_prefix("LOG_LINE: ") {
+                    let _ = tx.send(json.trim().to_string()).await;
+                }
+                line.clear();
+            }
+        });
+
+        Ok(rx)
+    }
 }
 
 async fn run_sync_loop(addr: String, tx: tokio::sync::watch::Sender<AgentState>) -> anyhow::Result<()> {

--- a/wazuh-agent-status-rust-client/src-tauri/src/agent.rs
+++ b/wazuh-agent-status-rust-client/src-tauri/src/agent.rs
@@ -72,9 +72,15 @@ impl AgentManager {
         // Spawn background task to keep the state in sync with the server
         tauri::async_runtime::spawn(async move {
             loop {
-                if let Err(e) = run_sync_loop(addr_for_loop.clone(), state_tx.clone()).await {
-                    eprintln!("Server sync loop error for {}: {}; retrying in 5s", addr_for_loop, e);
-                    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                match run_sync_loop(addr_for_loop.clone(), state_tx.clone()).await {
+                    Ok(()) => {
+                        log::warn!("Sync loop ended for {}; reconnecting in 2s", addr_for_loop);
+                        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+                    }
+                    Err(e) => {
+                        log::error!("Server sync loop error for {}: {}; retrying in 5s", addr_for_loop, e);
+                        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                    }
                 }
             }
         });
@@ -186,24 +192,36 @@ impl AgentManager {
 }
 
 async fn run_sync_loop(addr: String, tx: tokio::sync::watch::Sender<AgentState>) -> anyhow::Result<()> {
-    // Connect to server
+    log::info!("Connecting to Wazuh status server at {}...", addr);
+
     let stream = tokio::net::TcpStream::connect(&addr).await?;
+    log::info!("Connected to Wazuh status server at {}", addr);
+
     let (reader, mut writer) = tokio::io::split(stream);
     let mut reader = tokio::io::BufReader::new(reader);
 
-    // Subscribe to status updates
     use tokio::io::{AsyncWriteExt, AsyncBufReadExt};
     writer.write_all(b"subscribe-status\n").await?;
+    log::info!("Sent subscribe-status command");
 
     let mut line = String::new();
     while reader.read_line(&mut line).await? > 0 {
         if let Some(json) = line.strip_prefix("STATUS_UPDATE: ") {
-            if let Ok(state) = serde_json::from_str::<AgentState>(json.trim()) {
-                let _ = tx.send(state);
+            match serde_json::from_str::<AgentState>(json.trim()) {
+                Ok(state) => {
+                    let _ = tx.send(state.clone());
+                    log::debug!("Received state update: {:?}", state.status);
+                }
+                Err(e) => {
+                    log::warn!("Failed to parse STATUS_UPDATE JSON: {} — payload: {}", e, json.trim());
+                }
             }
+        } else {
+            log::debug!("Ignoring non-status line: {}", line.trim());
         }
         line.clear();
     }
 
+    log::warn!("Server closed status stream for {}", addr);
     Ok(())
 }

--- a/wazuh-agent-status-rust-client/src-tauri/src/commands.rs
+++ b/wazuh-agent-status-rust-client/src-tauri/src/commands.rs
@@ -47,3 +47,19 @@ pub async fn start_update(
 
     Ok(())
 }
+
+#[tauri::command]
+pub async fn start_log_stream(
+    window: tauri::Window,
+    manager: State<'_, Arc<AgentManager>>,
+) -> Result<(), String> {
+    let mut rx = manager.stream_logs().await.map_err(|e| e.to_string())?;
+
+    tauri::async_runtime::spawn(async move {
+        while let Some(line) = rx.recv().await {
+            let _ = window.emit("log-line", line);
+        }
+    });
+
+    Ok(())
+}

--- a/wazuh-agent-status-rust-client/src-tauri/src/lib.rs
+++ b/wazuh-agent-status-rust-client/src-tauri/src/lib.rs
@@ -63,7 +63,8 @@ pub fn run() {
             commands::get_config,
             commands::get_system_metrics,
             commands::check_for_updates,
-            commands::start_update
+            commands::start_update,
+            commands::start_log_stream
         ])
         .run(tauri::generate_context!());
 

--- a/wazuh-agent-status-rust-client/src/App.tsx
+++ b/wazuh-agent-status-rust-client/src/App.tsx
@@ -5,8 +5,9 @@ import "./App.css";
 import type { AppConfig, View } from "./types/app";
 import type { AgentStatus, SystemMetrics, UpdateStatus } from "./types/agent";
 
-import { IconHome, IconShield, IconSettings } from "./components/Icons";
+import { IconHome, IconLogs, IconShield, IconSettings } from "./components/Icons";
 import { StatusView } from "./components/StatusView";
+import { LogsView } from "./components/LogsView";
 import { UpdatesView } from "./components/UpdatesView";
 import { SettingsView } from "./components/SettingsView";
 
@@ -105,7 +106,7 @@ function App() {
   } as CSSProperties;
 
   const indicatorTop = (
-    { status: "10px", updates: "70px", settings: "130px" } as Record<View, string>
+    { status: "10px", logs: "70px", updates: "130px", settings: "190px" } as Record<View, string>
   )[activeView];
 
   return (
@@ -130,6 +131,17 @@ function App() {
               <IconHome />
             </button>
             <span className="tooltip">Overview</span>
+          </div>
+
+          <div className="tooltip-container">
+            <button
+              className={`nav-item ${activeView === "logs" ? "active" : ""}`}
+              onClick={() => setActiveView("logs")}
+              aria-label="Logs"
+            >
+              <IconLogs />
+            </button>
+            <span className="tooltip">Logs</span>
           </div>
 
           <div className="tooltip-container">
@@ -163,6 +175,7 @@ function App() {
 
       <main className="main-content">
         {activeView === "status" && <StatusView agentStatus={agentStatus} metrics={metrics} />}
+        {activeView === "logs" && <LogsView />}
         {activeView === "updates" && <UpdatesView updateInfo={updateInfo} agentStatus={agentStatus} />}
         {activeView === "settings" && <SettingsView config={config} agentStatus={agentStatus} />}
       </main>

--- a/wazuh-agent-status-rust-client/src/App.tsx
+++ b/wazuh-agent-status-rust-client/src/App.tsx
@@ -1,9 +1,10 @@
-import { useState, useEffect, type CSSProperties } from "react";
+import { useState, useEffect, useRef, useCallback, type CSSProperties } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
 import "./App.css";
 
 import type { AppConfig, View } from "./types/app";
-import type { AgentStatus, SystemMetrics, UpdateStatus } from "./types/agent";
+import type { AgentStatus, SystemMetrics, UpdateStatus, LogLine } from "./types/agent";
 
 import { IconHome, IconLogs, IconShield, IconSettings } from "./components/Icons";
 import { StatusView } from "./components/StatusView";
@@ -58,6 +59,51 @@ function App() {
     return (localStorage.getItem(STORAGE_KEY_VIEW) as View) || "status";
   });
 
+  // Global log stream state (persists across navigation)
+  const [logs, setLogs] = useState<LogLine[]>([]);
+  const [isLogStreaming, setIsLogStreaming] = useState(false);
+  const [logError, setLogError] = useState<string | null>(null);
+  const unlistenRef = useRef<(() => void) | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearLogTimeout = useCallback(() => {
+    if (timeoutRef.current) { window.clearTimeout(timeoutRef.current); timeoutRef.current = null; }
+  }, []);
+
+  const startLogStream = useCallback(async () => {
+    if (isLogStreaming) return;
+    setIsLogStreaming(true);
+    setLogError(null);
+    setLogs([]);
+    clearLogTimeout();
+
+    const unlisten = await listen<string>("log-line", (event) => {
+      clearLogTimeout();
+      try {
+        const parsed: LogLine = JSON.parse(event.payload);
+        setLogs((prev) => [...prev, parsed]);
+      } catch {
+        setLogs((prev) => [...prev, { raw: event.payload, level: "UNKNOWN" }]);
+      }
+      timeoutRef.current = window.setTimeout(() => {
+        setLogError("Idle timeout — no logs received for 5s. Server may be down.");
+        setIsLogStreaming(false);
+      }, 5000);
+    });
+
+    unlistenRef.current = unlisten;
+    invoke("start_log_stream").catch((e) => {
+      setLogError(`Failed to start log stream: ${e}`);
+      setIsLogStreaming(false);
+    });
+  }, [isLogStreaming, clearLogTimeout]);
+
+  const stopLogStream = useCallback(() => {
+    clearLogTimeout();
+    if (unlistenRef.current) { unlistenRef.current(); unlistenRef.current = null; }
+    setIsLogStreaming(false);
+  }, [clearLogTimeout]);
+
   useEffect(() => {
     localStorage.setItem(STORAGE_KEY_VIEW, activeView);
   }, [activeView]);
@@ -66,7 +112,7 @@ function App() {
     // Initial data fetch
     invoke<AppConfig>("get_config").then(setConfig).catch(console.error);
     invoke<UpdateStatus>("check_for_updates").then(setUpdateInfo).catch(console.error);
-    
+
     // Polling logic for real-time data
     const refreshData = () => {
       invoke<AgentStatus>("get_agent_status").then(setAgentStatus).catch(console.error);
@@ -76,8 +122,12 @@ function App() {
     refreshData();
     const statusTimer = setInterval(refreshData, STATUS_POLL_MS);
 
-    return () => clearInterval(statusTimer);
-  }, []);
+    return () => {
+      clearInterval(statusTimer);
+      clearLogTimeout();
+      if (unlistenRef.current) { unlistenRef.current(); unlistenRef.current = null; }
+    };
+  }, [clearLogTimeout]);
 
   useEffect(() => {
     const handleContextMenu = (e: MouseEvent) => {
@@ -175,7 +225,16 @@ function App() {
 
       <main className="main-content">
         {activeView === "status" && <StatusView agentStatus={agentStatus} metrics={metrics} />}
-        {activeView === "logs" && <LogsView />}
+        {activeView === "logs" && (
+          <LogsView
+            logs={logs}
+            isStreaming={isLogStreaming}
+            error={logError}
+            onStart={startLogStream}
+            onStop={stopLogStream}
+            onClear={() => setLogs([])}
+          />
+        )}
         {activeView === "updates" && <UpdatesView updateInfo={updateInfo} agentStatus={agentStatus} />}
         {activeView === "settings" && <SettingsView config={config} agentStatus={agentStatus} />}
       </main>

--- a/wazuh-agent-status-rust-client/src/App.tsx
+++ b/wazuh-agent-status-rust-client/src/App.tsx
@@ -64,31 +64,20 @@ function App() {
   const [isLogStreaming, setIsLogStreaming] = useState(false);
   const [logError, setLogError] = useState<string | null>(null);
   const unlistenRef = useRef<(() => void) | null>(null);
-  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const clearLogTimeout = useCallback(() => {
-    if (timeoutRef.current) { window.clearTimeout(timeoutRef.current); timeoutRef.current = null; }
-  }, []);
 
   const startLogStream = useCallback(async () => {
     if (isLogStreaming) return;
     setIsLogStreaming(true);
     setLogError(null);
     setLogs([]);
-    clearLogTimeout();
 
     const unlisten = await listen<string>("log-line", (event) => {
-      clearLogTimeout();
       try {
         const parsed: LogLine = JSON.parse(event.payload);
         setLogs((prev) => [...prev, parsed]);
       } catch {
         setLogs((prev) => [...prev, { raw: event.payload, level: "UNKNOWN" }]);
       }
-      timeoutRef.current = window.setTimeout(() => {
-        setLogError("Idle timeout — no logs received for 5s. Server may be down.");
-        setIsLogStreaming(false);
-      }, 5000);
     });
 
     unlistenRef.current = unlisten;
@@ -96,13 +85,12 @@ function App() {
       setLogError(`Failed to start log stream: ${e}`);
       setIsLogStreaming(false);
     });
-  }, [isLogStreaming, clearLogTimeout]);
+  }, [isLogStreaming]);
 
   const stopLogStream = useCallback(() => {
-    clearLogTimeout();
     if (unlistenRef.current) { unlistenRef.current(); unlistenRef.current = null; }
     setIsLogStreaming(false);
-  }, [clearLogTimeout]);
+  }, []);
 
   useEffect(() => {
     localStorage.setItem(STORAGE_KEY_VIEW, activeView);
@@ -124,10 +112,9 @@ function App() {
 
     return () => {
       clearInterval(statusTimer);
-      clearLogTimeout();
       if (unlistenRef.current) { unlistenRef.current(); unlistenRef.current = null; }
     };
-  }, [clearLogTimeout]);
+  }, []);
 
   useEffect(() => {
     const handleContextMenu = (e: MouseEvent) => {

--- a/wazuh-agent-status-rust-client/src/components/Icons.tsx
+++ b/wazuh-agent-status-rust-client/src/components/Icons.tsx
@@ -11,6 +11,16 @@ export const IconShield = () => (
   </svg>
 );
 
+export const IconLogs = () => (
+  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+    <polyline points="14 2 14 8 20 8" />
+    <line x1="16" y1="13" x2="8" y2="13" />
+    <line x1="16" y1="17" x2="8" y2="17" />
+    <polyline points="10 9 9 9 8 9" />
+  </svg>
+);
+
 export const IconSettings = () => (
   <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
     <circle cx="12" cy="12" r="3" />

--- a/wazuh-agent-status-rust-client/src/components/LogsView.tsx
+++ b/wazuh-agent-status-rust-client/src/components/LogsView.tsx
@@ -1,50 +1,18 @@
-import { useState, useEffect, useRef, useCallback } from "react";
-import { invoke } from "@tauri-apps/api/core";
-import { listen } from "@tauri-apps/api/event";
+import { useState, useEffect, useRef } from "react";
 import type { LogLine } from "../types/agent";
 
-export function LogsView() {
-  const [logs, setLogs] = useState<LogLine[]>([]);
+interface LogsViewProps {
+  logs: LogLine[];
+  isStreaming: boolean;
+  error: string | null;
+  onStart: () => void;
+  onStop: () => void;
+  onClear: () => void;
+}
+
+export function LogsView({ logs, isStreaming, error, onStart, onStop, onClear }: LogsViewProps) {
   const [filter, setFilter] = useState("");
-  const [isStreaming, setIsStreaming] = useState(false);
   const logEndRef = useRef<HTMLDivElement>(null);
-  const unlistenRef = useRef<(() => void) | null>(null);
-
-  const startStream = useCallback(async () => {
-    if (isStreaming) return;
-    setIsStreaming(true);
-    setLogs([]);
-
-    const unlisten = await listen<string>("log-line", (event) => {
-      try {
-        const parsed: LogLine = JSON.parse(event.payload);
-        setLogs((prev) => [...prev, parsed]);
-      } catch {
-        setLogs((prev) => [...prev, { raw: event.payload, level: "UNKNOWN" }]);
-      }
-    });
-
-    unlistenRef.current = unlisten;
-    invoke("start_log_stream").catch((e) => {
-      setLogs((prev) => [...prev, { raw: `[ERROR] Failed to start log stream: ${e}`, level: "ERROR" }]);
-      setIsStreaming(false);
-    });
-  }, [isStreaming]);
-
-  const stopStream = useCallback(() => {
-    if (unlistenRef.current) {
-      unlistenRef.current();
-      unlistenRef.current = null;
-    }
-    setIsStreaming(false);
-  }, []);
-
-  useEffect(() => {
-    startStream();
-    return () => {
-      stopStream();
-    };
-  }, []);
 
   useEffect(() => {
     logEndRef.current?.scrollIntoView({ behavior: "smooth" });
@@ -97,7 +65,7 @@ export function LogsView() {
         />
         <button
           className="update-button"
-          onClick={isStreaming ? stopStream : startStream}
+          onClick={isStreaming ? onStop : onStart}
           style={{ padding: "8px 16px", fontSize: "13px" }}
         >
           {isStreaming ? "Stop" : "Stream"}
@@ -118,9 +86,14 @@ export function LogsView() {
           lineHeight: 1.5,
         }}
       >
+        {error && (
+          <div style={{ color: "#f87171", textAlign: "center", padding: "12px", marginBottom: "8px", background: "#450a0a", borderRadius: "4px", fontWeight: 600 }}>
+            {error}
+          </div>
+        )}
         {filteredLogs.length === 0 ? (
           <div style={{ color: "#6b7280", textAlign: "center", padding: "20px" }}>
-            {isStreaming ? "Waiting for log lines..." : "Stream stopped."}
+            {isStreaming ? "Waiting for log lines..." : error ? null : "Click Stream to start."}
           </div>
         ) : (
           filteredLogs.map((log, i) => (
@@ -153,7 +126,7 @@ export function LogsView() {
         </span>
         <button
           className="update-button"
-          onClick={() => setLogs([])}
+          onClick={onClear}
           style={{ padding: "6px 12px", fontSize: "12px" }}
         >
           Clear

--- a/wazuh-agent-status-rust-client/src/components/LogsView.tsx
+++ b/wazuh-agent-status-rust-client/src/components/LogsView.tsx
@@ -1,0 +1,164 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import type { LogLine } from "../types/agent";
+
+export function LogsView() {
+  const [logs, setLogs] = useState<LogLine[]>([]);
+  const [filter, setFilter] = useState("");
+  const [isStreaming, setIsStreaming] = useState(false);
+  const logEndRef = useRef<HTMLDivElement>(null);
+  const unlistenRef = useRef<(() => void) | null>(null);
+
+  const startStream = useCallback(async () => {
+    if (isStreaming) return;
+    setIsStreaming(true);
+    setLogs([]);
+
+    const unlisten = await listen<string>("log-line", (event) => {
+      try {
+        const parsed: LogLine = JSON.parse(event.payload);
+        setLogs((prev) => [...prev, parsed]);
+      } catch {
+        setLogs((prev) => [...prev, { raw: event.payload, level: "UNKNOWN" }]);
+      }
+    });
+
+    unlistenRef.current = unlisten;
+    invoke("start_log_stream").catch((e) => {
+      setLogs((prev) => [...prev, { raw: `[ERROR] Failed to start log stream: ${e}`, level: "ERROR" }]);
+      setIsStreaming(false);
+    });
+  }, [isStreaming]);
+
+  const stopStream = useCallback(() => {
+    if (unlistenRef.current) {
+      unlistenRef.current();
+      unlistenRef.current = null;
+    }
+    setIsStreaming(false);
+  }, []);
+
+  useEffect(() => {
+    startStream();
+    return () => {
+      stopStream();
+    };
+  }, []);
+
+  useEffect(() => {
+    logEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [logs]);
+
+  const filteredLogs = logs.filter((log) => {
+    if (!filter.trim()) return true;
+    const term = filter.toLowerCase();
+    return (
+      log.raw.toLowerCase().includes(term) ||
+      log.level.toLowerCase().includes(term)
+    );
+  });
+
+  const levelColor = (level: string) => {
+    switch (level) {
+      case "ERROR":
+        return "#f87171";
+      case "WARNING":
+        return "#fbbf24";
+      case "INFO":
+        return "#4ade80";
+      case "DEBUG":
+        return "#60a5fa";
+      default:
+        return "#d1d5db";
+    }
+  };
+
+  return (
+    <div className="view-container">
+      <div className="subtitle">Diagnostics</div>
+      <h2 className="header title">Agent Logs</h2>
+
+      <div style={{ display: "flex", gap: "8px", marginBottom: "16px", alignItems: "center" }}>
+        <input
+          type="text"
+          placeholder="Filter logs (e.g. ERROR, WARNING)..."
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          style={{
+            flex: 1,
+            padding: "8px 12px",
+            borderRadius: "6px",
+            border: "1px solid var(--border)",
+            background: "var(--bg-secondary)",
+            color: "var(--text)",
+            fontSize: "13px",
+          }}
+        />
+        <button
+          className="update-button"
+          onClick={isStreaming ? stopStream : startStream}
+          style={{ padding: "8px 16px", fontSize: "13px" }}
+        >
+          {isStreaming ? "Stop" : "Stream"}
+        </button>
+      </div>
+
+      <div
+        className="log-container"
+        style={{
+          background: "#0a0a0a",
+          padding: "12px",
+          borderRadius: "8px",
+          fontSize: "11px",
+          fontFamily: "monospace",
+          maxHeight: "320px",
+          overflowY: "auto",
+          border: "1px solid #222",
+          lineHeight: 1.5,
+        }}
+      >
+        {filteredLogs.length === 0 ? (
+          <div style={{ color: "#6b7280", textAlign: "center", padding: "20px" }}>
+            {isStreaming ? "Waiting for log lines..." : "Stream stopped."}
+          </div>
+        ) : (
+          filteredLogs.map((log, i) => (
+            <div key={i} style={{ display: "flex", gap: "8px" }}>
+              <span
+                style={{
+                  color: levelColor(log.level),
+                  fontWeight: 700,
+                  minWidth: "70px",
+                  textTransform: "uppercase",
+                  fontSize: "10px",
+                  letterSpacing: "0.05em",
+                  userSelect: "none",
+                }}
+              >
+                {log.level}
+              </span>
+              <span style={{ color: "#e5e7eb", whiteSpace: "pre-wrap", wordBreak: "break-word" }}>
+                {log.raw}
+              </span>
+            </div>
+          ))
+        )}
+        <div ref={logEndRef} />
+      </div>
+
+      <div style={{ marginTop: "12px", display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+        <span style={{ fontSize: "11px", color: "#9ca3af" }}>
+          Showing {filteredLogs.length} of {logs.length} lines
+        </span>
+        <button
+          className="update-button"
+          onClick={() => setLogs([])}
+          style={{ padding: "6px 12px", fontSize: "12px" }}
+        >
+          Clear
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/wazuh-agent-status-rust-client/src/types/agent.ts
+++ b/wazuh-agent-status-rust-client/src/types/agent.ts
@@ -30,3 +30,10 @@ export interface SystemMetrics {
     used_memory: number;
     agent_running: boolean;
 }
+
+export type LogLevel = "ERROR" | "WARNING" | "INFO" | "DEBUG" | "UNKNOWN";
+
+export interface LogLine {
+    raw: string;
+    level: LogLevel;
+}

--- a/wazuh-agent-status-rust-client/src/types/app.ts
+++ b/wazuh-agent-status-rust-client/src/types/app.ts
@@ -24,4 +24,4 @@ export interface AppConfig {
 
 // Removed UpdateInfo — version status is now a string from server
 
-export type View = "status" | "updates" | "settings";
+export type View = "status" | "logs" | "updates" | "settings";

--- a/wazuh-agent-status-rust-server/src/config.rs
+++ b/wazuh-agent-status-rust-server/src/config.rs
@@ -157,6 +157,8 @@ pub struct AgentPaths {
 impl AgentPaths {
     /// Return the native paths for the OS this binary targets.
     pub fn native() -> Self {
+        let ossec_log_override = std::env::var("WAZUH_STATUS_OSSEC_LOG").ok().map(PathBuf::from);
+
         #[cfg(target_os = "linux")]
         {
             let base = PathBuf::from("/var/ossec");
@@ -168,7 +170,7 @@ impl AgentPaths {
                 pid_file:      base.join("var/run/wazuh-agentd.pid"),
                 update_script: base.join("active-response/bin/adorsys-update.sh"),
                 wazuh_control: base.join("bin/wazuh-control"),
-                ossec_log:     base.join("logs/ossec.log"),
+                ossec_log:     ossec_log_override.unwrap_or_else(|| base.join("logs/ossec.log")),
             }
         }
 
@@ -183,7 +185,7 @@ impl AgentPaths {
                 pid_file:      base.join("var/run/wazuh-agentd.pid"),
                 update_script: base.join("active-response/bin/adorsys-update.sh"),
                 wazuh_control: base.join("bin/wazuh-control"),
-                ossec_log:     base.join("logs/ossec.log"),
+                ossec_log:     ossec_log_override.unwrap_or_else(|| base.join("logs/ossec.log")),
             }
         }
 
@@ -198,7 +200,7 @@ impl AgentPaths {
                 pid_file:      PathBuf::new(), // not applicable on Windows
                 update_script: base.join("adorsys-update.bat"),
                 wazuh_control: base.join("wazuh-control.exe"), // Placeholder for Windows
-                ossec_log:     base.join(r"logs\ossec.log"),
+                ossec_log:     ossec_log_override.unwrap_or_else(|| base.join(r"logs\ossec.log")),
             }
         }
 

--- a/wazuh-agent-status-rust-server/src/config.rs
+++ b/wazuh-agent-status-rust-server/src/config.rs
@@ -200,7 +200,7 @@ impl AgentPaths {
                 pid_file:      PathBuf::new(), // not applicable on Windows
                 update_script: base.join("adorsys-update.bat"),
                 wazuh_control: base.join("wazuh-control.exe"), // Placeholder for Windows
-                ossec_log:     ossec_log_override.unwrap_or_else(|| base.join(r"logs\ossec.log")),
+                ossec_log:     ossec_log_override.unwrap_or_else(|| base.join(r"ossec.log")),
             }
         }
 

--- a/wazuh-agent-status-rust-server/src/config.rs
+++ b/wazuh-agent-status-rust-server/src/config.rs
@@ -150,6 +150,8 @@ pub struct AgentPaths {
     pub update_script: PathBuf,
     /// Path to the wazuh-control utility.
     pub wazuh_control: PathBuf,
+    /// Path to the Wazuh agent's ossec.log file.
+    pub ossec_log: PathBuf,
 }
 
 impl AgentPaths {
@@ -166,6 +168,7 @@ impl AgentPaths {
                 pid_file:      base.join("var/run/wazuh-agentd.pid"),
                 update_script: base.join("active-response/bin/adorsys-update.sh"),
                 wazuh_control: base.join("bin/wazuh-control"),
+                ossec_log:     base.join("logs/ossec.log"),
             }
         }
 
@@ -180,6 +183,7 @@ impl AgentPaths {
                 pid_file:      base.join("var/run/wazuh-agentd.pid"),
                 update_script: base.join("active-response/bin/adorsys-update.sh"),
                 wazuh_control: base.join("bin/wazuh-control"),
+                ossec_log:     base.join("logs/ossec.log"),
             }
         }
 
@@ -194,6 +198,7 @@ impl AgentPaths {
                 pid_file:      PathBuf::new(), // not applicable on Windows
                 update_script: base.join("adorsys-update.bat"),
                 wazuh_control: base.join("wazuh-control.exe"), // Placeholder for Windows
+                ossec_log:     base.join(r"logs\ossec.log"),
             }
         }
 

--- a/wazuh-agent-status-rust-server/src/manager.rs
+++ b/wazuh-agent-status-rust-server/src/manager.rs
@@ -275,15 +275,26 @@ impl AgentManager {
         tokio::spawn(async move {
             const HISTORY: usize = 50;
 
+            // Verify file exists before attempting anything.
+            if !tokio::fs::try_exists(&log_path).await.unwrap_or(false) {
+                let _ = tx.send(LogLine::from_raw(format!("[ERROR] Log file not found: {}", log_path.display()))).await;
+                return;
+            }
+
             // Send last N historical lines so the UI isn't empty on first connect.
-            if let Ok(content) = tokio::fs::read_to_string(&log_path).await {
-                let mut hist: Vec<&str> = Vec::with_capacity(HISTORY);
-                for line in content.lines() {
-                    hist.push(line);
-                    if hist.len() > HISTORY { hist.remove(0); }
+            match tokio::fs::read_to_string(&log_path).await {
+                Ok(content) => {
+                    let mut hist: Vec<&str> = Vec::with_capacity(HISTORY);
+                    for line in content.lines() {
+                        hist.push(line);
+                        if hist.len() > HISTORY { hist.remove(0); }
+                    }
+                    for line in hist {
+                        if tx.send(LogLine::from_raw(line.to_string())).await.is_err() { return; }
+                    }
                 }
-                for line in hist {
-                    if tx.send(LogLine::from_raw(line.to_string())).await.is_err() { return; }
+                Err(e) => {
+                    let _ = tx.send(LogLine::from_raw(format!("[WARNING] Could not read history (file may be locked): {e}"))).await;
                 }
             }
 
@@ -291,7 +302,7 @@ impl AgentManager {
             let file = match tokio::fs::File::open(&log_path).await {
                 Ok(f) => f,
                 Err(e) => {
-                    let _ = tx.send(LogLine::from_raw(format!("[ERROR] Cannot open log file: {e}"))).await;
+                    let _ = tx.send(LogLine::from_raw(format!("[ERROR] Cannot open log file for tailing: {e}"))).await;
                     return;
                 }
             };

--- a/wazuh-agent-status-rust-server/src/manager.rs
+++ b/wazuh-agent-status-rust-server/src/manager.rs
@@ -273,6 +273,21 @@ impl AgentManager {
         let log_path = self.paths.ossec_log.clone();
 
         tokio::spawn(async move {
+            const HISTORY: usize = 50;
+
+            // Send last N historical lines so the UI isn't empty on first connect.
+            if let Ok(content) = tokio::fs::read_to_string(&log_path).await {
+                let mut hist: Vec<&str> = Vec::with_capacity(HISTORY);
+                for line in content.lines() {
+                    hist.push(line);
+                    if hist.len() > HISTORY { hist.remove(0); }
+                }
+                for line in hist {
+                    if tx.send(LogLine::from_raw(line.to_string())).await.is_err() { return; }
+                }
+            }
+
+            // Re-open and tail from EOF for live lines.
             let file = match tokio::fs::File::open(&log_path).await {
                 Ok(f) => f,
                 Err(e) => {
@@ -280,9 +295,7 @@ impl AgentManager {
                     return;
                 }
             };
-
             let mut reader = BufReader::new(file);
-            // Jump to end so we only stream *new* lines (real-time tail).
             if let Err(e) = reader.seek(std::io::SeekFrom::End(0)).await {
                 let _ = tx.send(LogLine::from_raw(format!("[ERROR] Cannot seek log file: {e}"))).await;
                 return;

--- a/wazuh-agent-status-rust-server/src/manager.rs
+++ b/wazuh-agent-status-rust-server/src/manager.rs
@@ -127,25 +127,54 @@ impl AgentManager {
                         if should_attempt {
                             info!("Self-healing: Wazuh agent is inactive. Attempting restart...");
                             last_healing_attempt = Some(now);
-                            
-                            let control_path = self.paths.wazuh_control.clone();
-                            tokio::spawn(async move {
-                                let mut cmd = Command::new("sudo");
-                                cmd.arg(control_path).arg("restart");
-                                
-                                match cmd.output().await {
-                                    Ok(o) => {
-                                        if o.status.success() {
-                                            info!("Self-healing: Restart command executed successfully");
-                                        } else {
-                                            warn!("Self-healing: Restart command failed with exit code {}: {}", 
-                                                o.status.code().unwrap_or(-1),
-                                                String::from_utf8_lossy(&o.stderr));
-                                        }
-                                    },
-                                    Err(e) => warn!("Self-healing: Failed to spawn restart command: {e}"),
-                                }
-                            });
+
+                            #[cfg(not(target_os = "windows"))]
+                            {
+                                let control_path = self.paths.wazuh_control.clone();
+                                tokio::spawn(async move {
+                                    let mut cmd = Command::new("sudo");
+                                    cmd.arg(control_path).arg("restart");
+
+                                    match cmd.output().await {
+                                        Ok(o) => {
+                                            if o.status.success() {
+                                                info!("Self-healing: Restart command executed successfully");
+                                            } else {
+                                                warn!("Self-healing: Restart command failed with exit code {}: {}",
+                                                    o.status.code().unwrap_or(-1),
+                                                    String::from_utf8_lossy(&o.stderr));
+                                            }
+                                        },
+                                        Err(e) => warn!("Self-healing: Failed to spawn restart command: {e}"),
+                                    }
+                                });
+                            }
+
+                            #[cfg(target_os = "windows")]
+                            {
+                                tokio::spawn(async move {
+                                    let mut cmd = Command::new("powershell.exe");
+                                    cmd.args([
+                                        "-NoProfile",
+                                        "-NonInteractive",
+                                        "-Command",
+                                        "Restart-Service -Name WazuhSvc -Force",
+                                    ]);
+
+                                    match cmd.output().await {
+                                        Ok(o) => {
+                                            if o.status.success() {
+                                                info!("Self-healing: Restart command executed successfully");
+                                            } else {
+                                                warn!("Self-healing: Restart command failed with exit code {}: {}",
+                                                    o.status.code().unwrap_or(-1),
+                                                    String::from_utf8_lossy(&o.stderr));
+                                            }
+                                        },
+                                        Err(e) => warn!("Self-healing: Failed to spawn restart command: {e}"),
+                                    }
+                                });
+                            }
                         }
                     } else if new_state.status == crate::models::AgentStatus::Active {
                         // Just broadcast state; don't reset healing clock to maintain strict cooldown

--- a/wazuh-agent-status-rust-server/src/manager.rs
+++ b/wazuh-agent-status-rust-server/src/manager.rs
@@ -9,12 +9,12 @@ use tokio::time;
 use tracing::{info, warn};
 
 use crate::config::{AgentPaths, Config};
-use crate::models::{AgentState, ComponentUpdate, UpdateStatus, VersionInfo};
+use crate::models::{AgentState, ComponentUpdate, LogLine, UpdateStatus, VersionInfo};
 use crate::status_provider::StatusProvider;
 use crate::version_utils::fetch_version_info;
 use tokio::process::Command;
 use std::process::Stdio;
-use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncSeekExt, BufReader};
 use tokio::sync::mpsc;
 
 // ── Version cache ─────────────────────────────────────────────────────────────
@@ -256,6 +256,54 @@ impl AgentManager {
                 }
                 Err(e) => {
                     let _ = tx.send(format!("UPDATE_PROGRESS: [FAILURE] Failed to start update script (check sudoers): {e}")).await;
+                }
+            }
+        });
+
+        rx
+    }
+
+    // ── Log streaming ─────────────────────────────────────────────────────────
+
+    /// Open `ossec.log`, seek to the end, and stream new lines as they are
+    /// appended.  Returns an [`mpsc::Receiver`] that yields structured
+    /// [`LogLine`] values until the file is closed or the client disconnects.
+    pub async fn stream_logs(&self) -> mpsc::Receiver<LogLine> {
+        let (tx, rx) = mpsc::channel(256);
+        let log_path = self.paths.ossec_log.clone();
+
+        tokio::spawn(async move {
+            let file = match tokio::fs::File::open(&log_path).await {
+                Ok(f) => f,
+                Err(e) => {
+                    let _ = tx.send(LogLine::from_raw(format!("[ERROR] Cannot open log file: {e}"))).await;
+                    return;
+                }
+            };
+
+            let mut reader = BufReader::new(file);
+            // Jump to end so we only stream *new* lines (real-time tail).
+            if let Err(e) = reader.seek(std::io::SeekFrom::End(0)).await {
+                let _ = tx.send(LogLine::from_raw(format!("[ERROR] Cannot seek log file: {e}"))).await;
+                return;
+            }
+
+            let mut lines = reader.lines();
+            loop {
+                match lines.next_line().await {
+                    Ok(Some(line)) => {
+                        if tx.send(LogLine::from_raw(line)).await.is_err() {
+                            break; // Client disconnected
+                        }
+                    }
+                    Ok(None) => {
+                        // EOF — wait briefly for new data to be appended.
+                        tokio::time::sleep(Duration::from_millis(500)).await;
+                    }
+                    Err(e) => {
+                        let _ = tx.send(LogLine::from_raw(format!("[ERROR] Failed to read log line: {e}"))).await;
+                        break;
+                    }
                 }
             }
         });

--- a/wazuh-agent-status-rust-server/src/models.rs
+++ b/wazuh-agent-status-rust-server/src/models.rs
@@ -123,3 +123,42 @@ impl Default for AgentState {
         }
     }
 }
+
+/// A single line from the ossec.log file, structured for streaming to clients.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LogLine {
+    /// The raw, unmodified text of the log line.
+    pub raw: String,
+    /// Inferred severity level based on line content.
+    pub level: LogLevel,
+}
+
+/// Severity levels inferred from ossec.log content.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum LogLevel {
+    Error,
+    Warning,
+    Info,
+    Debug,
+    Unknown,
+}
+
+impl LogLine {
+    /// Create a new LogLine by analysing the raw text for known keywords.
+    pub fn from_raw(raw: String) -> Self {
+        let upper = raw.to_uppercase();
+        let level = if upper.contains("ERROR") || upper.contains("CRITICAL") || upper.contains("FATAL") {
+            LogLevel::Error
+        } else if upper.contains("WARNING") || upper.contains("WARN") {
+            LogLevel::Warning
+        } else if upper.contains("DEBUG") {
+            LogLevel::Debug
+        } else if upper.contains("INFO") {
+            LogLevel::Info
+        } else {
+            LogLevel::Unknown
+        };
+        Self { raw, level }
+    }
+}

--- a/wazuh-agent-status-rust-server/src/server.rs
+++ b/wazuh-agent-status-rust-server/src/server.rs
@@ -140,6 +140,12 @@ async fn handle_connection(
                 break; // Subscription ended — close connection
             }
 
+            // ── Log streaming ─────────────────────────────────────────────────
+            "subscribe-logs" => {
+                handle_log_stream(&mut writer, &manager).await?;
+                break;
+            }
+
             // ── Update triggers (compatible with Go protocol) ─────────────────
             "update" => {
                 start_update_stream_async(&manager, false).await;
@@ -245,6 +251,30 @@ where
     while let Some(line) = rx.recv().await {
         if let Err(e) = writer.write_all(format!("{line}\n").as_bytes()).await {
             warn!(error = %e, "Failed to write update log to client; stopping stream");
+            break;
+        }
+        let _ = writer.flush().await;
+    }
+
+    Ok(())
+}
+
+/// Handle a `subscribe-logs` session: tail `ossec.log` in real-time and
+/// pipe structured JSON lines back to the client.
+async fn handle_log_stream<W>(
+    writer: &mut W,
+    manager: &AgentManager,
+) -> tokio::io::Result<()>
+where
+    W: AsyncWriteExt + Unpin,
+{
+    let mut rx = manager.stream_logs().await;
+
+    while let Some(log_line) = rx.recv().await {
+        let json = serde_json::to_string(&log_line).unwrap_or_default();
+        let msg = format!("LOG_LINE: {json}\n");
+        if let Err(e) = writer.write_all(msg.as_bytes()).await {
+            warn!(error = %e, "Failed to write log line to client; stopping stream");
             break;
         }
         let _ = writer.flush().await;

--- a/wazuh-agent-status-rust-server/src/status_provider/mod.rs
+++ b/wazuh-agent-status-rust-server/src/status_provider/mod.rs
@@ -13,8 +13,18 @@ pub const UNIX_AGENT_PROCESSES: &[&str] = &[
 ];
 
 pub const WINDOWS_AGENT_PROCESSES: &[&str] = &[
-    "Wazuh.exe",
+    // Wazuh 4.x on Windows (original naming)
+    "ossec-agent.exe",
+    "ossec-agentd.exe",
+    "ossec-logcollector.exe",
+    "ossec-syscheckd.exe",
+    "ossec-execd.exe",
+    // Wazuh 5.x+ on Windows (renamed binaries)
+    "wazuh-agent.exe",
     "wazuh-agentd.exe",
+    "wazuh-logcollector.exe",
+    "wazuh-syscheckd.exe",
+    "wazuh-execd.exe",
 ];
 
 /// Abstraction over platform-specific Wazuh agent status retrieval.

--- a/wazuh-agent-status-rust-server/src/status_provider/windows.rs
+++ b/wazuh-agent-status-rust-server/src/status_provider/windows.rs
@@ -14,6 +14,7 @@ use crate::errors::{Result, ServerError};
 use crate::group_extractor;
 use crate::models::{AgentStatus, ConnectionStatus};
 use crate::status_provider::StatusProvider;
+use tracing::{debug, trace};
 
 pub struct WindowsStatusProvider {
     paths: AgentPaths,
@@ -126,11 +127,20 @@ impl StatusProvider for WindowsStatusProvider {
 
         for process in sys.processes().values() {
             let name = process.name().to_string_lossy();
+            trace!(process = %name, cpu = %process.cpu_usage(), mem = process.memory(), "Scanning process");
             if crate::status_provider::WINDOWS_AGENT_PROCESSES.contains(&name.as_ref()) {
+                debug!(process = %name, cpu = %process.cpu_usage(), mem = process.memory(), "Matched Wazuh process");
                 total_cpu += process.cpu_usage();
                 total_rss += process.memory();
                 found = true;
             }
+        }
+
+        if !found {
+            let available: Vec<_> = sys.processes().values()
+                .map(|p| p.name().to_string_lossy().into_owned())
+                .collect();
+            debug!(processes = ?available, "No Wazuh processes matched; available process names shown above");
         }
 
         let cpu_count = sys.cpus().len() as f32;

--- a/wazuh-agent-status-rust-server/tests/serialization.rs
+++ b/wazuh-agent-status-rust-server/tests/serialization.rs
@@ -9,6 +9,7 @@ fn test_agent_state_serialization() {
         tray_version: "1.8.0".to_string(),
         groups: vec!["default".to_string(), "linux".to_string()],
         metrics: SystemMetrics::default(),
+        self_healing_enabled: true,
     };
 
     let json = serde_json::to_string(&state).expect("Failed to serialize");
@@ -32,7 +33,8 @@ fn test_agent_state_deserialization() {
             "memory_usage": 0.0,
             "total_memory": 0,
             "used_memory": 0
-        }
+        },
+        "self_healing_enabled": true
     }"#;
 
     let state: AgentState = serde_json::from_str(json).expect("Failed to deserialize");

--- a/wazuh-agent-status-rust-server/tests/server_cmds.rs
+++ b/wazuh-agent-status-rust-server/tests/server_cmds.rs
@@ -60,6 +60,21 @@ async fn test_server_concurrent_clients() {
     }
 }
 
+#[tokio::test]
+async fn test_server_subscribe_logs() {
+    let (_manager, addr) = setup_test_server().await;
+    
+    let stream = TcpStream::connect(&addr).await.unwrap();
+    let (mut reader_raw, mut writer) = tokio::io::split(stream);
+    
+    writer.write_all(b"subscribe-logs\n").await.unwrap();
+    
+    let mut reader = BufReader::new(&mut reader_raw).lines();
+    let line = reader.next_line().await.unwrap().unwrap();
+    assert!(line.starts_with("LOG_LINE:"));
+    // The stream closes after the error line since the log file doesn't exist in tests
+}
+
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 async fn setup_test_server() -> (Arc<AgentManager>, String) {


### PR DESCRIPTION
What this PR does
- Adds a Logs tab in the app to watch ossec.log live
- Log lines show in color: green (INFO), yellow (WARNING), red (ERROR)
You can filter and search logs
- Shows the last 50 lines immediately, so the panel isn't empty
- Works on Linux and macOS
Windows
- ossec.log path set to C:\Program Files (x86)\ossec-agent\ossec.log
- File locking and restart errors, as seen in the screenshot below, will be fixed 
<img width="1735" height="175" alt="image" src="https://github.com/user-attachments/assets/71f509ec-689e-41f5-beb1-56b8858bd533" />



closes #113