### PR TITLE
fix(config): improve app configuration loading and add resource path fallback

### DIFF
--- a/wazuh-agent-status-rust-client/src-tauri/src/config.rs
+++ b/wazuh-agent-status-rust-client/src-tauri/src/config.rs
@@ -33,19 +33,22 @@ pub struct AppConfig {
 impl AppConfig {
     pub fn load(app: &tauri::AppHandle) -> Result<Self, String> {
         use tauri::Manager;
-        
-        let config_path = app.path().resolve("app_config.json", tauri::path::BaseDirectory::AppConfig)
-            .map_err(|e| format!("Failed to resolve config path: {}", e))?;
 
-        if !config_path.exists() {
-            let dev_path = std::path::PathBuf::from("app_config.json");
-            if dev_path.exists() {
-                return Self::load_from_path(dev_path);
-            }
-            return Err(format!("Config file not found at {:?}", config_path));
+        // 1. Try bundled resource (works for release builds & all platforms)
+        let resource_path = app.path().resolve("app_config.json", tauri::path::BaseDirectory::Resource)
+            .map_err(|e| format!("Failed to resolve resource path: {}", e))?;
+
+        if resource_path.exists() {
+            return Self::load_from_path(resource_path);
         }
-        
-        Self::load_from_path(config_path)
+
+        // 2. Fallback: current working directory (for dev / cargo run / npm run tauri dev)
+        let dev_path = std::path::PathBuf::from("app_config.json");
+        if dev_path.exists() {
+            return Self::load_from_path(dev_path);
+        }
+
+        Err("Config file app_config.json not found in bundled resources or current directory".to_string())
     }
 
     fn load_from_path(path: std::path::PathBuf) -> Result<Self, String> {

--- a/wazuh-agent-status-rust-client/src-tauri/tauri.conf.json
+++ b/wazuh-agent-status-rust-client/src-tauri/tauri.conf.json
@@ -30,6 +30,9 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "resources": [
+      "app_config.json"
+    ],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
**what this pr does:**
- Bundles `app_config.json` into the Tauri client via `bundle.resources` in `tauri.conf.json` so it ships inside the `.exe`/`.msi`/`.app`/`.deb` installers.
- Updates `AppConfig::load()` to read the config from `BaseDirectory::Resource` first, with a fallback to the current working directory for `cargo run` / `npm run tauri dev`.
- Fixes silent startup crashes on `Linux`, `macOS`, and `Windows` where the app aborted because `app_config.json` was never deployed by any installer.

closes #136 