### PR TITLE
fix(config): enhance error handling and clarify comments in AppConfig loading

### DIFF
--- a/wazuh-agent-status-rust-client/src-tauri/src/config.rs
+++ b/wazuh-agent-status-rust-client/src-tauri/src/config.rs
@@ -34,7 +34,7 @@ impl AppConfig {
     pub fn load(app: &tauri::AppHandle) -> Result<Self, String> {
         use tauri::Manager;
 
-        // 1. Try bundled resource (works for release builds & all platforms)
+        // 1. Try bundled resource (allows override in .deb/.msi/.app installs)
         let resource_path = app.path().resolve("app_config.json", tauri::path::BaseDirectory::Resource)
             .map_err(|e| format!("Failed to resolve resource path: {}", e))?;
 
@@ -48,16 +48,20 @@ impl AppConfig {
             return Self::load_from_path(dev_path);
         }
 
-        Err("Config file app_config.json not found in bundled resources or current directory".to_string())
+        // 3. Ultimate fallback: compile-time embedded config
+        //    Guaranteed to exist for raw binaries moved anywhere (e.g. /usr/local/bin)
+        let embedded = include_str!("../app_config.json");
+        serde_json::from_str(embedded)
+            .map_err(|e| format!("Failed to parse embedded config: {}", e))
     }
 
     fn load_from_path(path: std::path::PathBuf) -> Result<Self, String> {
         let config_str = fs::read_to_string(&path)
             .map_err(|e| format!("Failed to read config file at {:?}: {}", path, e))?;
-            
+
         let config: AppConfig = serde_json::from_str(&config_str)
             .map_err(|e| format!("Failed to parse config file: {}", e))?;
-            
+
         Ok(config)
     }
 }


### PR DESCRIPTION
- Fixes silent startup crash on Linux, macOS, and Windows caused by app_config.json missing at runtime — no installer or release pipeline was deploying the file.
- Embeds the default config at compile time via include_str! so the raw binary is self-contained and works regardless of where it is installed 

close #136 