### PR TITLE
fix: centralize OS guard into shared utils and apply to all platform scripts

### DIFF
--- a/.github/workflows/scripts.yaml
+++ b/.github/workflows/scripts.yaml
@@ -8,6 +8,9 @@ on:
     paths:
       - 'scripts/**'
   workflow_dispatch:
+  push:
+    branches:
+      - fix/add-os-guard-to-all-scripts
 
 env:
   WAZUH_MANAGER: "127.0.0.1"

--- a/.github/workflows/scripts.yaml
+++ b/.github/workflows/scripts.yaml
@@ -8,9 +8,6 @@ on:
     paths:
       - 'scripts/**'
   workflow_dispatch:
-  push:
-    branches:
-      - fix/add-os-guard-to-all-scripts
 
 env:
   WAZUH_MANAGER: "127.0.0.1"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Use REAL_HOME and add sudo-safe function execution ([`b55d353`](https://github.com/ADORSYS-GIS/wazuh-agent-status/commit/b55d35369e2ee30062943b759c457b49dca13afc))
 - Replace single brackets with double brackets for improved condition checks ([`72af293`](https://github.com/ADORSYS-GIS/wazuh-agent-status/commit/72af293e5b21f193cd45ead32ab3990507ec7fc5))
 - Fix code formatting ([`8929d60`](https://github.com/ADORSYS-GIS/wazuh-agent-status/commit/8929d60d596893d177828d81c7d82114454b671d))
+- Centralize OS guard into shared utils and apply to all platform scripts ([`8d20978`](https://github.com/ADORSYS-GIS/wazuh-agent-status/commit/8d2097833f3c89d51609cd18a0b6a7787d6341ef)), Signed-off-by:Awambeng Rodrick <awambengrodrick@gmail.com>
 
 ### Documentation
 
@@ -27,7 +28,10 @@ All notable changes to this project will be documented in this file.
 - Update CHANGELOG.md and checksums [skip ci] ([`7ee4c7a`](https://github.com/ADORSYS-GIS/wazuh-agent-status/commit/7ee4c7a05af2b909c8d01adfef0fa5fd2b693064))
 - Update CHANGELOG.md and checksums [skip ci] ([`105b3bb`](https://github.com/ADORSYS-GIS/wazuh-agent-status/commit/105b3bbe70e1c1e7541fe855d9ea5f111a813107))
 - Update CHANGELOG.md and checksums [skip ci] ([`4fe2a33`](https://github.com/ADORSYS-GIS/wazuh-agent-status/commit/4fe2a33160b01dee2c7294b7294f4a1431c6b576))
+<<<<<<< HEAD
 - Update CHANGELOG.md and checksums [skip ci] ([`b17b36a`](https://github.com/ADORSYS-GIS/wazuh-agent-status/commit/b17b36aeefd96534714635277b779170d6142467))
+=======
+>>>>>>> 7dab4d2 (docs: update CHANGELOG.md and checksums [skip ci])
 
 ### Features
 
@@ -49,6 +53,7 @@ All notable changes to this project will be documented in this file.
 - Standardize PowerShell scripts, improve LogsView UI robustness ([`ba1bec6`](https://github.com/ADORSYS-GIS/wazuh-agent-status/commit/ba1bec67a21fc1d471a96f17170bbb1fa1650e03)), Signed-off-by:Awambeng Rodrick <awambengrodrick@gmail.com>
 - Improve repository reference handling in PowerShell scripts ([`7a0c65b`](https://github.com/ADORSYS-GIS/wazuh-agent-status/commit/7a0c65be81e71fbc47ec6741fc11c0d6a2ead14d)), Signed-off-by:Awambeng Rodrick <awambengrodrick@gmail.com>
 - Modernize Rust code with let-else/if-let chains, update Cargo edition ([`629f59a`](https://github.com/ADORSYS-GIS/wazuh-agent-status/commit/629f59a2cbd701bb41cb1653557d8beb82b24ac6)), Signed-off-by:Awambeng Rodrick <awambengrodrick@gmail.com>
+- Remove unused APP_VERSION variable from Windows scripts ([`9fe4145`](https://github.com/ADORSYS-GIS/wazuh-agent-status/commit/9fe4145f9ec585b397d2fe22c55098e46c421f6c)), Signed-off-by:Awambeng Rodrick <awambengrodrick@gmail.com>
 
 ## 0.4.2.rc1-user - 2025-07-16
 

--- a/scripts/linux/adorsys-update.sh
+++ b/scripts/linux/adorsys-update.sh
@@ -9,12 +9,6 @@ else
     set -eu
 fi
 
-# OS guard early in the script
-if [[ "$(uname -s)" != "Linux" ]]; then
-    printf "%s\n" "[ERROR] This installation script is intended for Linux systems. Please use the appropriate script for your operating system." >&2
-    exit 1
-fi
-
 readonly WAZUH_AGENT_STATUS_REPO_REF="user-main"
 readonly WAZUH_AGENT_STATUS_REPO_URL="https://raw.githubusercontent.com/ADORSYS-GIS/wazuh-agent-status/$WAZUH_AGENT_STATUS_REPO_REF"
 readonly WAZUH_AGENT_REPO_REF="${WAZUH_AGENT_REPO_REF:-main}"
@@ -56,6 +50,7 @@ if [[ -z "$EXPECTED_HASH" ]] || [[ "$EXPECTED_HASH" != "$ACTUAL_HASH" ]]; then
 fi
 
 . "$TMP_DIR/utils.sh"
+ensure_os "Linux"
 
 trap cleanup EXIT
 

--- a/scripts/linux/install.sh
+++ b/scripts/linux/install.sh
@@ -7,12 +7,6 @@ else
     set -eu
 fi
 
-# OS guard early in the script
-if [[ "$(uname -s)" != "Linux" ]]; then
-    printf "%s\n" "[ERROR] This installation script is intended for Linux systems. Please use the appropriate script for your operating system." >&2
-    exit 1
-fi
-
 APP_VERSION=${APP_VERSION:-"0.5.0"}
 
 # Common configuration
@@ -55,6 +49,7 @@ if [[ -z "$EXPECTED_HASH" ]] || [[ "$EXPECTED_HASH" != "$ACTUAL_HASH" ]]; then
 fi
 
 . "$TMP_DIR/utils.sh"
+ensure_os "Linux"
 
 trap cleanup EXIT
 

--- a/scripts/linux/uninstall.sh
+++ b/scripts/linux/uninstall.sh
@@ -7,12 +7,6 @@ else
     set -eu
 fi
 
-# OS guard early in the script
-if [[ "$(uname -s)" != "Linux" ]]; then
-    printf "%s\n" "[ERROR] This installation script is intended for Linux systems. Please use the appropriate script for your operating system." >&2
-    exit 1
-fi
-
 # Common configuration
 WAZUH_AGENT_STATUS_REPO_REF=${WAZUH_AGENT_STATUS_REPO_REF:-"user-main"}
 WAZUH_AGENT_STATUS_REPO_URL="https://raw.githubusercontent.com/ADORSYS-GIS/wazuh-agent-status/$WAZUH_AGENT_STATUS_REPO_REF"
@@ -53,6 +47,7 @@ if [[ -z "$EXPECTED_HASH" ]] || [[ "$EXPECTED_HASH" != "$ACTUAL_HASH" ]]; then
 fi
 
 . "$TMP_DIR/utils.sh"
+ensure_os "Linux"
 
 trap cleanup EXIT
 

--- a/scripts/macos/adorsys-update.sh
+++ b/scripts/macos/adorsys-update.sh
@@ -9,12 +9,6 @@ else
     set -eu
 fi
 
-# OS guard early in the script
-if [[ "$(uname -s)" != "Darwin" ]]; then
-    printf "%s\n" "[ERROR] This installation script is intended for macOS systems. Please use the appropriate script for your operating system." >&2
-    exit 1
-fi
-
 readonly WAZUH_AGENT_STATUS_REPO_REF="user-main"
 readonly WAZUH_AGENT_STATUS_REPO_URL="https://raw.githubusercontent.com/ADORSYS-GIS/wazuh-agent-status/$WAZUH_AGENT_STATUS_REPO_REF"
 readonly WAZUH_AGENT_REPO_REF="${WAZUH_AGENT_REPO_REF:-main}"
@@ -55,6 +49,7 @@ if [[ -z "$EXPECTED_HASH" ]] || [[ "$EXPECTED_HASH" != "$ACTUAL_HASH" ]]; then
 fi
 
 . "$TMP_DIR/utils.sh"
+ensure_os "Darwin"
 
 trap cleanup EXIT
 

--- a/scripts/macos/install.sh
+++ b/scripts/macos/install.sh
@@ -51,6 +51,7 @@ if [[ -z "$EXPECTED_HASH" ]] || [[ "$EXPECTED_HASH" != "$ACTUAL_HASH" ]]; then
 fi
 
 . "$TMP_DIR/utils.sh"
+ensure_os "Darwin"
 
 trap cleanup EXIT
 export CHECKSUMS_FILE="$CHECKSUMS_FILE"

--- a/scripts/macos/uninstall.sh
+++ b/scripts/macos/uninstall.sh
@@ -7,13 +7,6 @@ else
     set -eu
 fi
 
-
-# OS guard early in the script
-if [[ "$(uname -s)" != "Darwin" ]]; then
-    printf "%s\n" "[ERROR] This installation script is intended for macOS systems. Please use the appropriate script for your operating system." >&2
-    exit 1
-fi
-
 # Common configuration
 WAZUH_AGENT_STATUS_REPO_REF=${WAZUH_AGENT_STATUS_REPO_REF:-"user-main"}
 WAZUH_AGENT_STATUS_REPO_URL="https://raw.githubusercontent.com/ADORSYS-GIS/wazuh-agent-status/$WAZUH_AGENT_STATUS_REPO_REF"
@@ -54,6 +47,7 @@ if [[ -z "$EXPECTED_HASH" ]] || [[ "$EXPECTED_HASH" != "$ACTUAL_HASH" ]]; then
 fi
 
 . "$TMP_DIR/utils.sh"
+ensure_os "Darwin"
 
 trap cleanup EXIT
 

--- a/scripts/shared/utils.ps1
+++ b/scripts/shared/utils.ps1
@@ -189,6 +189,13 @@ function Download-And-VerifyFile {
     return $true
 }
 
+# Ensure the script is running on Windows
+function EnsureWindows {
+    if ($PSVersionTable.PSEdition -eq "Core" -and -not $IsWindows) {
+        ErrorExit "This script is intended for Windows systems. Please use the appropriate script for your operating system."
+    }
+}
+
 # Ensure the script is running with administrator privileges
 function EnsureAdmin {
     if (-not ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")) {

--- a/scripts/shared/utils.sh
+++ b/scripts/shared/utils.sh
@@ -63,6 +63,24 @@ command_exists() {
     return $?
 }
 
+# Ensure the script is running on the expected operating system
+ensure_os() {
+    local expected_os="$1"
+    local actual_os
+    actual_os=$(uname -s)
+
+    if [[ "$actual_os" != "$expected_os" ]]; then
+        local os_name
+        case "$expected_os" in
+            Darwin) os_name="macOS" ;;
+            Linux)  os_name="Linux" ;;
+            *)      os_name="$expected_os" ;;
+        esac
+        error_exit "This script is intended for ${os_name} systems. Detected OS: ${actual_os}. Please use the appropriate script for your operating system."
+    fi
+    return 0
+}
+
 # Detect system architecture
 detect_architecture() {
     local arch

--- a/scripts/windows/adorsys-update.ps1
+++ b/scripts/windows/adorsys-update.ps1
@@ -52,6 +52,7 @@ try {
     . $U
 } catch { Write-Error "Bootstrap failed"; exit 1 }
 
+EnsureWindows
 EnsureAdmin
 
 # Cleanup bootstrap files on exit

--- a/scripts/windows/adorsys-update.ps1
+++ b/scripts/windows/adorsys-update.ps1
@@ -39,7 +39,6 @@ if (-not $IsAdmin) {
 
 # Configuration
 
-$APP_VERSION = if ($env:APP_VERSION) { $env:APP_VERSION } else { "0.5.0" }
 $REPO_REF = if ($env:WAZUH_AGENT_STATUS_REPO_REF) { $env:WAZUH_AGENT_STATUS_REPO_REF } else { "user-main" }
 $REPO_URL = "https://raw.githubusercontent.com/ADORSYS-GIS/wazuh-agent-status/$REPO_REF"
 $AGENT_REPO_REF = if ($env:WAZUH_AGENT_REPO_REF) { $env:WAZUH_AGENT_REPO_REF } else { "main" }

--- a/scripts/windows/install.ps1
+++ b/scripts/windows/install.ps1
@@ -20,6 +20,7 @@ try {
     . $U
 } catch { Write-Error "Bootstrap failed: $($_.Exception.Message)"; exit 1 }
 
+EnsureWindows
 EnsureAdmin
 
 # Determine architecture

--- a/scripts/windows/uninstall.ps1
+++ b/scripts/windows/uninstall.ps1
@@ -4,7 +4,6 @@ $ErrorActionPreference = "Stop"
 
 # Configuration
 
-$APP_VERSION = if ($env:APP_VERSION) { $env:APP_VERSION } else { "0.5.0" }
 $REPO_REF = if ($env:WAZUH_AGENT_STATUS_REPO_REF) { $env:WAZUH_AGENT_STATUS_REPO_REF } else { "user-main" }
 $REPO_URL = "https://raw.githubusercontent.com/ADORSYS-GIS/wazuh-agent-status/$REPO_REF"
 $TMP = Join-Path $env:TEMP "wazuh-agent-status-install"; if (-not (Test-Path $TMP)) { mkdir $TMP | Out-Null }

--- a/scripts/windows/uninstall.ps1
+++ b/scripts/windows/uninstall.ps1
@@ -16,6 +16,7 @@ try {
     . $U
 } catch { Write-Error "Bootstrap failed"; exit 1 }
 
+EnsureWindows
 EnsureAdmin
 
 # Environment Variables with Defaults


### PR DESCRIPTION
Adds reusable OS guard functions to shared utilities and applies them across all platform scripts to prevent accidental execution on the wrong OS.

## Changes
- Added `ensure_os()` to `scripts/shared/utils.sh` — validates expected OS via `uname -s`
- Added `EnsureWindows` to `scripts/shared/utils.ps1` — validates Windows via `$IsWindows`
- Replaced all inline OS guards in Linux/macOS scripts with `ensure_os` calls
- Added missing OS guard to `scripts/macos/install.sh` (the bug)
- Added `EnsureWindows` calls to all Windows PowerShell scripts (previously unguarded)

## Scripts updated
- `scripts/linux/install.sh`, `uninstall.sh`, `adorsys-update.sh`
- `scripts/macos/install.sh`, `uninstall.sh`, `adorsys-update.sh`
- `scripts/windows/install.ps1`, `uninstall.ps1`, `adorsys-update.ps1`

Closes #146 