### PR TITLE
fix: use separate repo ref for wazuh-agent downloads

### DIFF
--- a/scripts/linux/adorsys-update.sh
+++ b/scripts/linux/adorsys-update.sh
@@ -17,6 +17,7 @@ fi
 
 readonly WAZUH_AGENT_STATUS_REPO_REF="user-main"
 readonly WAZUH_AGENT_STATUS_REPO_URL="https://raw.githubusercontent.com/ADORSYS-GIS/wazuh-agent-status/$WAZUH_AGENT_STATUS_REPO_REF"
+readonly WAZUH_AGENT_REPO_REF="${WAZUH_AGENT_REPO_REF:-main}"
 readonly AWK_PRINT_FIRST_COL='{print $1}'
 
 # Source shared utilities
@@ -66,7 +67,7 @@ fi
 
 # Environment Variables with Defaults
 WAZUH_MANAGER=${WAZUH_MANAGER:-"wazuh.example.com"}
-readonly WAZUH_AGENT_REPO_URL="https://raw.githubusercontent.com/ADORSYS-GIS/wazuh-agent/$WAZUH_AGENT_STATUS_REPO_REF"
+readonly WAZUH_AGENT_REPO_URL="https://raw.githubusercontent.com/ADORSYS-GIS/wazuh-agent/$WAZUH_AGENT_REPO_REF"
 
 # Linux-specific constants
 ICON_PATH='/usr/share/pixmaps/wazuh-logo.png'

--- a/scripts/macos/adorsys-update.sh
+++ b/scripts/macos/adorsys-update.sh
@@ -17,6 +17,7 @@ fi
 
 readonly WAZUH_AGENT_STATUS_REPO_REF="user-main"
 readonly WAZUH_AGENT_STATUS_REPO_URL="https://raw.githubusercontent.com/ADORSYS-GIS/wazuh-agent-status/$WAZUH_AGENT_STATUS_REPO_REF"
+readonly WAZUH_AGENT_REPO_REF="${WAZUH_AGENT_REPO_REF:-main}"
 
 # Source shared utilities
 TMP_DIR=$(mktemp -d)
@@ -59,7 +60,7 @@ trap cleanup EXIT
 
 # Environment Variables with Defaults
 WAZUH_MANAGER=${WAZUH_MANAGER:-"wazuh.example.com"}
-readonly WAZUH_AGENT_REPO_URL="https://raw.githubusercontent.com/ADORSYS-GIS/wazuh-agent/$WAZUH_AGENT_STATUS_REPO_REF"
+readonly WAZUH_AGENT_REPO_URL="https://raw.githubusercontent.com/ADORSYS-GIS/wazuh-agent/$WAZUH_AGENT_REPO_REF"
 readonly SCRIPT_URL="$WAZUH_AGENT_REPO_URL/scripts/macos/setup-agent.sh"
 
 # macOS-specific constants

--- a/scripts/windows/adorsys-update.ps1
+++ b/scripts/windows/adorsys-update.ps1
@@ -42,6 +42,7 @@ if (-not $IsAdmin) {
 $APP_VERSION = if ($env:APP_VERSION) { $env:APP_VERSION } else { "0.5.0" }
 $REPO_REF = if ($env:WAZUH_AGENT_STATUS_REPO_REF) { $env:WAZUH_AGENT_STATUS_REPO_REF } else { "user-main" }
 $REPO_URL = "https://raw.githubusercontent.com/ADORSYS-GIS/wazuh-agent-status/$REPO_REF"
+$AGENT_REPO_REF = if ($env:WAZUH_AGENT_REPO_REF) { $env:WAZUH_AGENT_REPO_REF } else { "main" }
 $TMP = Join-Path $env:TEMP "wazuh-agent-status-install"; if (-not (Test-Path $TMP)) { mkdir $TMP | Out-Null }
 
 try {
@@ -63,8 +64,8 @@ Set-StrictMode -Version Latest
 # ---- Configuration Variables ----
 $WAZUH_MANAGER           = if ($env:WAZUH_MANAGER) { $env:WAZUH_MANAGER } else { "wazuh.example.com" }
 $OSSEC_PATH              = "C:\Program Files (x86)\ossec-agent\"
-$VERSION_URL             = "https://raw.githubusercontent.com/ADORSYS-GIS/wazuh-agent/$REPO_REF/versions.json"
-$STABLE_SETUP_SCRIPT_URL = "https://raw.githubusercontent.com/ADORSYS-GIS/wazuh-agent/$REPO_REF/scripts/windows/setup-agent.ps1"
+$VERSION_URL             = "https://raw.githubusercontent.com/ADORSYS-GIS/wazuh-agent/$AGENT_REPO_REF/versions.json"
+$STABLE_SETUP_SCRIPT_URL = "https://raw.githubusercontent.com/ADORSYS-GIS/wazuh-agent/$AGENT_REPO_REF/scripts/windows/setup-agent.ps1"
 
 # ---- Globals ----
 $ActiveResponsesLogDir = Join-Path $OSSEC_PATH "active-response"


### PR DESCRIPTION
The update scripts were using `WAZUH_AGENT_STATUS_REPO_REF` (user-main) to build download URLs for both the wazuh-agent-status and wazuh-agent repositories. Since wazuh-agent has no `user-main` branch (its default is main), all setup-agent.sh downloads failed with 404.

This PR introduces a separate `WAZUH_AGENT_REPO_REF` variable (defaulting to main) for the wazuh-agent repo across Linux, macOS, and Windows update scripts.