### PR TITLE
ci: inject gateway url from github secrets during build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -84,11 +84,14 @@ jobs:
 
       - name: Configure Gateway URL from Secrets
         shell: bash
+        env:
+          GATEWAY_URL_DEV: ${{ secrets.WAZUH_GATEWAY_URL_DEV }}
+          GATEWAY_URL_PROD: ${{ secrets.WAZUH_GATEWAY_URL_PROD }}
         run: |
           if [[ "${{ github.ref_name }}" == *"rc"* ]]; then
-            GATEWAY_URL="${{ secrets.WAZUH_GATEWAY_URL_DEV }}"
+            GATEWAY_URL="${GATEWAY_URL_DEV}"
           else
-            GATEWAY_URL="${{ secrets.WAZUH_GATEWAY_URL_PROD }}"
+            GATEWAY_URL="${GATEWAY_URL_PROD}"
           fi
           
           if [[ -z "$GATEWAY_URL" ]]; then
@@ -98,7 +101,6 @@ jobs:
             CONFIG_FILE="${{ env.CLIENT_DIR }}/src-tauri/app_config.json"
             jq --arg url "$GATEWAY_URL" '.gateway_url = $url' "$CONFIG_FILE" > temp.json && mv temp.json "$CONFIG_FILE"
           fi
-
       - name: Build Tauri Client (Tray App)
         run: |
           cd ${{ env.CLIENT_DIR }}
@@ -178,11 +180,14 @@ jobs:
 
       - name: Configure Gateway URL from Secrets
         shell: bash
+        env:
+          GATEWAY_URL_DEV: ${{ secrets.WAZUH_GATEWAY_URL_DEV }}
+          GATEWAY_URL_PROD: ${{ secrets.WAZUH_GATEWAY_URL_PROD }}
         run: |
           if [[ "${{ github.ref_name }}" == *"rc"* ]]; then
-            GATEWAY_URL="${{ secrets.WAZUH_GATEWAY_URL_DEV }}"
+            GATEWAY_URL="${GATEWAY_URL_DEV}"
           else
-            GATEWAY_URL="${{ secrets.WAZUH_GATEWAY_URL_PROD }}"
+            GATEWAY_URL="${GATEWAY_URL_PROD}"
           fi
           
           if [[ -z "$GATEWAY_URL" ]]; then
@@ -252,12 +257,14 @@ jobs:
           copy target\release\wazuh-agent-status-rust-server.exe ..\dist\${{ env.SERVER_APP_NAME }}-windows-${{ matrix.arch }}.exe
 
       - name: Configure Gateway URL from Secrets
-        shell: bash
+        env:
+          GATEWAY_URL_DEV: ${{ secrets.WAZUH_GATEWAY_URL_DEV }}
+          GATEWAY_URL_PROD: ${{ secrets.WAZUH_GATEWAY_URL_PROD }}
         run: |
           if [[ "${{ github.ref_name }}" == *"rc"* ]]; then
-            GATEWAY_URL="${{ secrets.WAZUH_GATEWAY_URL_DEV }}"
+            GATEWAY_URL="${GATEWAY_URL_DEV}"
           else
-            GATEWAY_URL="${{ secrets.WAZUH_GATEWAY_URL_PROD }}"
+            GATEWAY_URL="${GATEWAY_URL_PROD}"
           fi
           
           if [[ -z "$GATEWAY_URL" ]]; then

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -192,7 +192,8 @@ jobs:
           fi
           
           if [[ -z "$GATEWAY_URL" ]]; then
-            echo "Warning: WAZUH_GATEWAY_URL secret is not set!"
+            echo "Error: WAZUH_GATEWAY_URL secret is not set!"
+            exit 1
           else
             echo "Configuring gateway_url..."
             CONFIG_FILE="${{ env.CLIENT_DIR }}/src-tauri/app_config.json"
@@ -269,7 +270,8 @@ jobs:
           fi
           
           if [[ -z "$GATEWAY_URL" ]]; then
-            echo "Warning: WAZUH_GATEWAY_URL secret is not set!"
+            echo "Error: WAZUH_GATEWAY_URL secret is not set!"
+            exit 1
           else
             echo "Configuring gateway_url..."
             CONFIG_FILE="${{ env.CLIENT_DIR }}/src-tauri/app_config.json"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -82,6 +82,23 @@ jobs:
           mkdir -p ../dist
           cp target/x86_64-unknown-linux-musl/release/wazuh-agent-status-rust-server ../dist/${{ env.SERVER_APP_NAME }}-linux-${{ matrix.arch }}
 
+      - name: Configure Gateway URL from Secrets
+        shell: bash
+        run: |
+          if [[ "${{ github.ref_name }}" == *"rc"* ]]; then
+            GATEWAY_URL="${{ secrets.WAZUH_GATEWAY_URL_DEV }}"
+          else
+            GATEWAY_URL="${{ secrets.WAZUH_GATEWAY_URL_PROD }}"
+          fi
+          
+          if [[ -z "$GATEWAY_URL" ]]; then
+            echo "Warning: WAZUH_GATEWAY_URL secret is not set!"
+          else
+            echo "Configuring gateway_url..."
+            CONFIG_FILE="${{ env.CLIENT_DIR }}/src-tauri/app_config.json"
+            jq --arg url "$GATEWAY_URL" '.gateway_url = $url' "$CONFIG_FILE" > temp.json && mv temp.json "$CONFIG_FILE"
+          fi
+
       - name: Build Tauri Client (Tray App)
         run: |
           cd ${{ env.CLIENT_DIR }}
@@ -159,6 +176,23 @@ jobs:
           mkdir -p ../dist
           cp target/release/wazuh-agent-status-rust-server ../dist/${{ env.SERVER_APP_NAME }}-darwin-${{ matrix.arch }}
 
+      - name: Configure Gateway URL from Secrets
+        shell: bash
+        run: |
+          if [[ "${{ github.ref_name }}" == *"rc"* ]]; then
+            GATEWAY_URL="${{ secrets.WAZUH_GATEWAY_URL_DEV }}"
+          else
+            GATEWAY_URL="${{ secrets.WAZUH_GATEWAY_URL_PROD }}"
+          fi
+          
+          if [[ -z "$GATEWAY_URL" ]]; then
+            echo "Warning: WAZUH_GATEWAY_URL secret is not set!"
+          else
+            echo "Configuring gateway_url..."
+            CONFIG_FILE="${{ env.CLIENT_DIR }}/src-tauri/app_config.json"
+            jq --arg url "$GATEWAY_URL" '.gateway_url = $url' "$CONFIG_FILE" > temp.json && mv temp.json "$CONFIG_FILE"
+          fi
+
       - name: Build Tauri Client (Tray App)
         run: |
           cd ${{ env.CLIENT_DIR }}
@@ -216,6 +250,23 @@ jobs:
           cargo build --release
           if not exist ..\dist mkdir ..\dist
           copy target\release\wazuh-agent-status-rust-server.exe ..\dist\${{ env.SERVER_APP_NAME }}-windows-${{ matrix.arch }}.exe
+
+      - name: Configure Gateway URL from Secrets
+        shell: bash
+        run: |
+          if [[ "${{ github.ref_name }}" == *"rc"* ]]; then
+            GATEWAY_URL="${{ secrets.WAZUH_GATEWAY_URL_DEV }}"
+          else
+            GATEWAY_URL="${{ secrets.WAZUH_GATEWAY_URL_PROD }}"
+          fi
+          
+          if [[ -z "$GATEWAY_URL" ]]; then
+            echo "Warning: WAZUH_GATEWAY_URL secret is not set!"
+          else
+            echo "Configuring gateway_url..."
+            CONFIG_FILE="${{ env.CLIENT_DIR }}/src-tauri/app_config.json"
+            jq --arg url "$GATEWAY_URL" '.gateway_url = $url' "$CONFIG_FILE" > temp.json && mv temp.json "$CONFIG_FILE"
+          fi
 
       - name: Build Tauri Client (Tray App)
         shell: bash

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -95,7 +95,8 @@ jobs:
           fi
           
           if [[ -z "$GATEWAY_URL" ]]; then
-            echo "Warning: WAZUH_GATEWAY_URL secret is not set!"
+            echo "Error: WAZUH_GATEWAY_URL secret is not set!"
+            exit 1
           else
             echo "Configuring gateway_url..."
             CONFIG_FILE="${{ env.CLIENT_DIR }}/src-tauri/app_config.json"


### PR DESCRIPTION
### Description
This PR updates the release workflow (`release.yaml`) to dynamically configure the gateway URL for the Tauri client during build time, using GitHub secrets.
* **Pre-releases (tags containing `rc`):** Dynamically uses the value from the `WAZUH_GATEWAY_URL_DEV` secret.
* **Stable/Production releases:** Dynamically uses the value from the `WAZUH_GATEWAY_URL_PROD` secret.