### PR TITLE
fix: reset agent status to Unknown when server goes offline

### DIFF
--- a/wazuh-agent-status-rust-client/src-tauri/src/agent.rs
+++ b/wazuh-agent-status-rust-client/src-tauri/src/agent.rs
@@ -81,10 +81,14 @@ impl AgentManager {
             loop {
                 match run_sync_loop(addr_for_loop.clone(), state_tx.clone()).await {
                     Ok(()) => {
+                        // Server closed the stream – reset to Unknown before retrying
+                        let _ = state_tx.send(AgentState::default());
                         log::warn!("Sync loop ended for {}; reconnecting in 2s", addr_for_loop);
                         tokio::time::sleep(std::time::Duration::from_secs(2)).await;
                     }
                     Err(e) => {
+                        // Connection failed – reset to Unknown before retrying
+                        let _ = state_tx.send(AgentState::default());
                         log::error!(
                             "Server sync loop error for {}: {}; retrying in 5s",
                             addr_for_loop,


### PR DESCRIPTION
**Description**
When the status server stops, the background sync loop exits but never clears the `watch` channel, so the last known state (e.g. `Active`) kept being served to the UI and system tray indefinitely.

Fixed by resetting the channel to `AgentState::default()` (all `Unknown`) in both reconnect arms of the sync loop, immediately after the connection drops.

**Testing**
1. Start the server → confirm status shows `Active`
2. Stop the server → status should switch to `Unknown` within ~5 seconds
3. Restart the server → status should recover automatically

closes #198 
